### PR TITLE
Calling "statusSettingsFromAddr" function failed in MySQL innodb memcached plugin

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -847,10 +847,13 @@ func (c *Client) statsSettingsFromAddr(addr net.Addr, cb func(map[string]string)
 		stats := map[string]string{}
 		for err == nil && !bytes.Equal(line, resultEnd) {
 			s := bytes.Split(line, []byte(" "))
-			if len(s) != 3 || !bytes.HasPrefix(s[0], resultStatPrefix) {
+			if len(s) == 3 {
+				stats[string(s[1])] = string(bytes.TrimSpace(s[2]))
+			} else if len(s) == 4 {
+				stats[string(s[1])] = string(bytes.TrimSpace(s[2])) + "-" + string(bytes.TrimSpace(s[2]))
+			} else {
 				return fmt.Errorf("memcache: unexpected stats line format %q", line)
 			}
-			stats[string(s[1])] = string(bytes.TrimSpace(s[2]))
 			line, err = rw.ReadSlice('\n')
 			if err != nil {
 				return err


### PR DESCRIPTION
Hi,

When using memcached with the MySQL InnoDB memcached plugin, a "stats settings" failure occurs.

```
memcache: unexpected stats line format "STAT logger standard error
```

The "stats settings" result in the MySQL InnoDB memcached plugin is shown below.
```
stats settings
STAT maxbytes 67108864
STAT maxconns 1000
..skip ..
STAT item_size_max 1048576
STAT topkeys 0
STAT logger standard error
END
```
The problem occurs in a four-word case in `STAT logger standard error`.

```
stats := map[string]string{}
for err == nil && !bytes.Equal(line, resultEnd) {
	s := bytes.Split(line, []byte(" "))
	if len(s) != 3 || !bytes.HasPrefix(s[0], resultStatPrefix) {
		return fmt.Errorf("memcache: unexpected stats line format %q", line)
	}
	stats[string(s[1])] = string(bytes.TrimSpace(s[2]))
	line, err = rw.ReadSlice('\n')
	if err != nil {
		return err
	}
}
```

If it is not three words at the bottom, it is the part that returns as an error. So I changed it to parse up to four words: And the problem is gone. In order to use the MySQL InnoDB memcached plugin well, please check this.
```
stats := map[string]string{}
for err == nil && !bytes.Equal(line, resultEnd) {
	s := bytes.Split(line, []byte(" "))
	if len(s) == 3 {
		stats[string(s[1])] = string(bytes.TrimSpace(s[2]))
	} else if len(s) == 4 {
		stats[string(s[1])] = string(bytes.TrimSpace(s[2])) + "-" + string(bytes.TrimSpace(s[2]))
	} else {
		return fmt.Errorf("memcache: unexpected stats line format %q", line)
	}
	line, err = rw.ReadSlice('\n')
	if err != nil {
		return err
	}
}
```

Best Regards,
Chan.